### PR TITLE
Remove reference to isNil to fix issue with verdaccio 4.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,9 @@ class DynamicGroupPlugin {
   }
   allow_unpublish(user, pkg, callback) {
     const action = 'unpublish';
-    const hasSupport = pkg[action] == null ? false : pkg[action];
+    const isDefined = pkg[action] === null || pkg[action] === undefined;
+
+    const hasSupport = isDefined ? pkg[action] : false;
 
     if (hasSupport === false) {
       return callback(null, undefined);

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ class DynamicGroupPlugin {
   }
   allow_unpublish(user, pkg, callback) {
     const action = 'unpublish';
-    const hasSupport = _lodash.default.isNil(pkg[action]) === false ? pkg[action] : false;
+    const hasSupport = pkg[action] == null ? false : pkg[action];
 
     if (hasSupport === false) {
       return callback(null, undefined);


### PR DESCRIPTION
I was getting an error with `_lodash` not being defined with Verdaccio 4.2, so I replaced it to not use the global `_lodash`